### PR TITLE
Avoid the use of ghc-dump

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -2,21 +2,25 @@ default:
 
 csv:
 	# ds
-	
-	ghc-dump summarize `find ../.. -name '*-0000.cbor'` | parse-ghc-dump-summary --sort --filter 'HList/Baseline/Baseline' --file-is-number >hlist-baseline.csv
-	ghc-dump summarize `find ../.. -name '*-0000.cbor'` | parse-ghc-dump-summary --sort --filter 'HList/LetAs/LetAs'       --file-is-number >hlist-letas.csv
-	ghc-dump summarize `find ../.. -name '*-0000.cbor'` | parse-ghc-dump-summary --sort --filter 'HList/LetAsCPS/LetAsCPS' --file-is-number >hlist-letas-cps.csv
 
-	ghc-dump summarize `find ../.. -name '*-0000.cbor'` | parse-ghc-dump-summary --sort --filter 'Ap/Baseline/Baseline' --file-is-number >ap-baseline.csv
-	ghc-dump summarize `find ../.. -name '*-0000.cbor'` | parse-ghc-dump-summary --sort --filter 'Ap/Let/Let'           --file-is-number >ap-let.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/HList/Baseline/Baseline(.*)\.dump-ds$$' | sort >hlist-baseline.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/HList/LetAs/LetAs(.*)\.dump-ds$$'       | sort >hlist-letas.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/HList/LetAsCPS/LetAsCPS(.*)\.dump-ds$$' | sort >hlist-letas-cps.csv
 
-        # simpl
+	parse-dump-files --dist ../dist-newstyle --match '.*/Ap/Baseline/Baseline(.*)\.dump-ds$$'    | sort >ap-baseline.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/Ap/Let/Let(.*)\.dump-ds$$'              | sort >ap-let.csv
 
-	ghc-dump summarize `find ../.. -name '*-0001.cbor'` | parse-ghc-dump-summary --sort --filter 'HList/Baseline/Baseline' --file-is-number >simpl-hlist-baseline.csv
-	ghc-dump summarize `find ../.. -name '*-0001.cbor'` | parse-ghc-dump-summary --sort --filter 'HList/LetAs/LetAs'       --file-is-number >simpl-hlist-letas.csv
-	ghc-dump summarize `find ../.. -name '*-0001.cbor'` | parse-ghc-dump-summary --sort --filter 'HList/LetAsCPS/LetAsCPS' --file-is-number >simpl-hlist-letas-cps.csv
+	# simpl
 
-	ghc-dump summarize `find ../.. -name '*-0001.cbor'` | parse-ghc-dump-summary --sort --filter 'Ap/Baseline/Baseline' --file-is-number >simpl-ap-baseline.csv
-	ghc-dump summarize `find ../.. -name '*-0001.cbor'` | parse-ghc-dump-summary --sort --filter 'Ap/Let/Let'           --file-is-number >simpl-ap-let.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/HList/Baseline/Baseline(.*)\.dump-simpl$$' | sort >simpl-hlist-baseline.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/HList/LetAs/LetAs(.*)\.dump-simpl$$'       | sort >simpl-hlist-letas.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/HList/LetAsCPS/LetAsCPS(.*)\.dump-simpl$$' | sort >simpl-hlist-letas-cps.csv
+
+	parse-dump-files --dist ../dist-newstyle --match '.*/Ap/Baseline/Baseline(.*)\.dump-simpl$$'    | sort >simpl-ap-baseline.csv
+	parse-dump-files --dist ../dist-newstyle --match '.*/Ap/Let/Let(.*)\.dump-simpl$$'              | sort >simpl-ap-let.csv
+
 images:
 	gnuplot benchmarks.gnuplot
+
+clean:
+	rm -f *.csv *.png

--- a/test/Test/Size/Ap/Baseline/Baseline010.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline010.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline010 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline020.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline020.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline020 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline030.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline030.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline030 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline040.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline040.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline040 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline050.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline050.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline050 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline060.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline060.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline060 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline070.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline070.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline070 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline080.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline080.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline080 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline090.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline090.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline090 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Baseline/Baseline100.hs
+++ b/test/Test/Size/Ap/Baseline/Baseline100.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.Ap.Baseline.Baseline100 where
 
 import Test.Infra

--- a/test/Test/Size/Ap/Let/Let010.hs
+++ b/test/Test/Size/Ap/Let/Let010.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let010 where

--- a/test/Test/Size/Ap/Let/Let020.hs
+++ b/test/Test/Size/Ap/Let/Let020.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let020 where

--- a/test/Test/Size/Ap/Let/Let030.hs
+++ b/test/Test/Size/Ap/Let/Let030.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let030 where

--- a/test/Test/Size/Ap/Let/Let040.hs
+++ b/test/Test/Size/Ap/Let/Let040.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let040 where

--- a/test/Test/Size/Ap/Let/Let050.hs
+++ b/test/Test/Size/Ap/Let/Let050.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let050 where

--- a/test/Test/Size/Ap/Let/Let060.hs
+++ b/test/Test/Size/Ap/Let/Let060.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let060 where

--- a/test/Test/Size/Ap/Let/Let070.hs
+++ b/test/Test/Size/Ap/Let/Let070.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let070 where

--- a/test/Test/Size/Ap/Let/Let080.hs
+++ b/test/Test/Size/Ap/Let/Let080.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let080 where

--- a/test/Test/Size/Ap/Let/Let090.hs
+++ b/test/Test/Size/Ap/Let/Let090.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let090 where

--- a/test/Test/Size/Ap/Let/Let100.hs
+++ b/test/Test/Size/Ap/Let/Let100.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.Ap.Let.Let100 where

--- a/test/Test/Size/HList/Baseline/Baseline010.hs
+++ b/test/Test/Size/HList/Baseline/Baseline010.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline010 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline020.hs
+++ b/test/Test/Size/HList/Baseline/Baseline020.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline020 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline030.hs
+++ b/test/Test/Size/HList/Baseline/Baseline030.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline030 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline040.hs
+++ b/test/Test/Size/HList/Baseline/Baseline040.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline040 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline050.hs
+++ b/test/Test/Size/HList/Baseline/Baseline050.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline050 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline060.hs
+++ b/test/Test/Size/HList/Baseline/Baseline060.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline060 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline070.hs
+++ b/test/Test/Size/HList/Baseline/Baseline070.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline070 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline080.hs
+++ b/test/Test/Size/HList/Baseline/Baseline080.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline080 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline090.hs
+++ b/test/Test/Size/HList/Baseline/Baseline090.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline090 where
 
 import Test.Infra

--- a/test/Test/Size/HList/Baseline/Baseline100.hs
+++ b/test/Test/Size/HList/Baseline/Baseline100.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 module Test.Size.HList.Baseline.Baseline100 where
 
 import Test.Infra

--- a/test/Test/Size/HList/LetAs/LetAs010.hs
+++ b/test/Test/Size/HList/LetAs/LetAs010.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs010 where

--- a/test/Test/Size/HList/LetAs/LetAs020.hs
+++ b/test/Test/Size/HList/LetAs/LetAs020.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs020 where

--- a/test/Test/Size/HList/LetAs/LetAs030.hs
+++ b/test/Test/Size/HList/LetAs/LetAs030.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs030 where

--- a/test/Test/Size/HList/LetAs/LetAs040.hs
+++ b/test/Test/Size/HList/LetAs/LetAs040.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs040 where

--- a/test/Test/Size/HList/LetAs/LetAs050.hs
+++ b/test/Test/Size/HList/LetAs/LetAs050.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs050 where

--- a/test/Test/Size/HList/LetAs/LetAs060.hs
+++ b/test/Test/Size/HList/LetAs/LetAs060.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs060 where

--- a/test/Test/Size/HList/LetAs/LetAs070.hs
+++ b/test/Test/Size/HList/LetAs/LetAs070.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs070 where

--- a/test/Test/Size/HList/LetAs/LetAs080.hs
+++ b/test/Test/Size/HList/LetAs/LetAs080.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs080 where

--- a/test/Test/Size/HList/LetAs/LetAs090.hs
+++ b/test/Test/Size/HList/LetAs/LetAs090.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs090 where

--- a/test/Test/Size/HList/LetAs/LetAs100.hs
+++ b/test/Test/Size/HList/LetAs/LetAs100.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAs.LetAs100 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS010.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS010.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS010 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS020.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS020.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS020 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS030.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS030.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS030 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS040.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS040.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS040 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS050.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS050.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS050 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS060.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS060.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS060 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS070.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS070.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS070 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS080.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS080.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS080 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS090.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS090.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS090 where

--- a/test/Test/Size/HList/LetAsCPS/LetAsCPS100.hs
+++ b/test/Test/Size/HList/LetAsCPS/LetAsCPS100.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#if defined(USE_GHC_DUMP)
-{-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
-#endif
-
 {-# OPTIONS_GHC -fplugin=TypeLet #-}
 
 module Test.Size.HList.LetAsCPS.LetAsCPS100 where

--- a/typelet.cabal
+++ b/typelet.cabal
@@ -175,12 +175,6 @@ test-suite test-typelet
     ghc-options:
         -Wall
 
-    if flag(use-ghc-dump)
-      cpp-options:
-          -DUSE_GHC_DUMP
-      build-depends:
-          ghc-dump-core
-
 -- To use the doctest tests, enable flag build-doctest-examples
 test-suite doctest-typelet
     type:
@@ -218,10 +212,6 @@ executable doctest-examples-typelet
 
     if !flag(build-doctest-examples)
       buildable: False
-
-Flag use-ghc-dump
-  Description: Use ghc-dump (for size measurements)
-  Default: False
 
 Flag build-doctest-examples
   Description: Build doctest-examples-typelet (for testing only)


### PR DESCRIPTION
We now just parse the -ddump-xyz output to get the sizes. This is faster
for compilation and works with all ghc versions.